### PR TITLE
Converted QueryDict to dict as it made in oa_login()

### DIFF
--- a/django_oneall/views.py
+++ b/django_oneall/views.py
@@ -94,7 +94,8 @@ def oa_profile(request):
         'form': EmailForm({'email': request.user.email})
     }
     if 'connection_token' in request.POST:
-        OneAllAuthBackend(request.user).authenticate(**request.POST)
+        auth_with = dict(request.POST.items())
+        OneAllAuthBackend(request.user).authenticate(**auth_with)
     elif 'email' in request.POST and request.user.email != request.POST['email']:
         csrf_check(request)
         EmailTokenAuthBackend(request.user).issue(request.POST['email'])


### PR DESCRIPTION
QueryDict with POST data contains dict with one-item lists, like 'connection_token': ['xxx']. It makes link to OneAll wrong, like "https://<sitename>.api.oneall.com/connection/['xxx'].json" instead of "https://<sitename>.api.oneall.com/connection/xxx.json".
