### PR TITLE
fix for issue #21

### DIFF
--- a/django_oneall/models.py
+++ b/django_oneall/models.py
@@ -122,8 +122,8 @@ def _find_unique_username(current):
     If not unique or not given, tries to derive a new username that is.
     """
     user_model = get_user_model()
-    max_length = user_model._meta.get_field('username').max_length
-
+    # max_length = user_model._meta.get_field('username').max_length
+    max_length = settings.max_username_length
     def exists(n):
         return user_model.objects.filter(username=n).exists()
 
@@ -146,7 +146,8 @@ def get_pseudo_random_user(seed):
     """ Creates or finds a user with a pseudo-random username and no further information.
     :param seed: A hashable object used to find the user. Will not be stored. """
     user_model = get_user_model()
-    max_length = user_model._meta.get_field('username').max_length
+    # max_length = user_model._meta.get_field('username').max_length
+    max_length = settings.max_username_length
     alphabet = 'AaBbCcDdEeFfGgHhIiJjKkLlMmNnOoPpQqRrSsTtUuVvWwXxYyZz'  # [chr(i+65)+chr(i+97) for i in range(26)]
     not_so_random = Random(seed)
     username = ''.join(map(lambda x: not_so_random.choice(alphabet), range(max_length)))

--- a/docs/settings.rst
+++ b/docs/settings.rst
@@ -55,9 +55,23 @@ Here's a different, more detailed alternative to the third step::
             'grid_sizes': [7, 5],
             # Any setting allowed in the login widget assistant can be put here.
         },
-        'store_user_info': True,
+        'store_user_info': False,
+        'max_username_length': 30,
         'email_token_expiration_hours': 3,
     }
+
+In the above example, the ``store_user_info`` feature is set to ``False`` (default is True).  This
+setting provides your users with true anonymity, as none of the information provided by
+oneall.com is saved or even cached.  Instead the user's oneall identification token is hashed
+and stored as the username.
+
+The example above also makes use of the ``max_username_length`` setting.  (default value of this field
+is introspected via get_user_model()). This setting is *only* relevant when using ``store_user_info=False``.
+The primary reason for this new setting is that Django 1.10 included a migration which altered the
+auth.User model's username field max_length from 30 to 150 chars.  This means if your were making
+use of the ``store_user_info=False`` setting with Django<=1.9 and upgrade to Django>=1.10 your pre-existing
+users **will be misidentified**. If this is the case, you should set this value to `30`
+
 
 If you plan to use E-mail Token authentication, you must also `configure your e-mail backend`_.
 Here's a good setting for development::


### PR DESCRIPTION
I've only manually tested this on Django 1.11.4/Python 2.7.3, but I am finally able to login to my user account created with Django 1.8.x.

I didn't add a version bump.  

I didn't update the docs, primarily because I couldn't find where the 'store_user_info' setting was explained, and wasn't sure if there is duplication between `README.rst` and what's in the `docs` dir.  I could add docs for both store_user_info and max_username_length if you want.  It would be nice for me to learn the doc build process/upload to readthedocs.org etc.

let me know if you want any changes.
